### PR TITLE
Add multilingual website support

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,4 +3,8 @@ This is the Content - Authorlinks plugin for Joomla 3.2+.
 
 This plugin has been created as an alternative to Joomla's core **Content - Contacts** plugin. Instead of simply link the author name to the associated contact page, it let you choose to link directly to the webpage or to the email of the associated contact.
 
+## New
+Add multilingual website support : You can now associate a contact to the author for each desired languages.
+
+
 See https://github.com/mattiaverga/authorlinks/wiki for more help.

--- a/README.md
+++ b/README.md
@@ -3,8 +3,14 @@ This is the Content - Authorlinks plugin for Joomla 3.2+.
 
 This plugin has been created as an alternative to Joomla's core **Content - Contacts** plugin. Instead of simply link the author name to the associated contact page, it let you choose to link directly to the webpage or to the email of the associated contact.
 
-## New
-Add multilingual website support : You can now associate a contact to the author for each desired languages.
-
-
 See https://github.com/mattiaverga/authorlinks/wiki for more help.
+
+## Changelog
+### v1.1
+* Add multilingual website support (thanks to Cedric Frossard)
+
+### v1.0.1
+* Fix license information header
+
+### v1.0
+* Initial release

--- a/authorlinks.php
+++ b/authorlinks.php
@@ -149,6 +149,7 @@ class plgContentAuthorlinks extends JPlugin
                 
                 $query->select($db->quoteName('webpage'));
                 $query->from($db->quoteName('#__contact_details', 'contact'));
+                $query->where('contact.published = 1');
                 $query->where($db->quoteName('contact.user_id') . ' = ' . (int) $author_id);
 
                 if (JLanguageMultilang::isEnabled() == 1)
@@ -179,6 +180,7 @@ class plgContentAuthorlinks extends JPlugin
                 
                 $query->select($db->quoteName('email_to'));
                 $query->from($db->quoteName('#__contact_details', 'contact'));
+                $query->where('contact.published = 1');
                 $query->where($db->quoteName('contact.user_id') . ' = ' . (int) $author_id);
 
                 if (JLanguageMultilang::isEnabled() == 1)

--- a/authorlinks.php
+++ b/authorlinks.php
@@ -125,7 +125,8 @@ class plgContentAuthorlinks extends JPlugin
                 {
                     $query->where('(contact.language in '
                         . '(' . $db->quote(JFactory::getLanguage()->getTag()) . ',' . $db->quote('*') . ') '
-                        . ' OR contact.language IS NULL)');
+                        . 'OR contact.language IS NULL) ' 
+                        . 'ORDER BY contact.language REGEXP \'^[a-z]\' DESC, contact.language');
                 }
 
                 $db->setQuery($query);
@@ -156,7 +157,8 @@ class plgContentAuthorlinks extends JPlugin
                 {
                     $query->where('(contact.language in '
                         . '(' . $db->quote(JFactory::getLanguage()->getTag()) . ',' . $db->quote('*') . ') '
-                        . ' OR contact.language IS NULL)');
+                        . 'OR contact.language IS NULL) ' 
+                        . 'ORDER BY contact.language REGEXP \'^[a-z]\' DESC, contact.language');
                 }
 
                 $db->setQuery($query);
@@ -187,7 +189,8 @@ class plgContentAuthorlinks extends JPlugin
                 {
                     $query->where('(contact.language in '
                         . '(' . $db->quote(JFactory::getLanguage()->getTag()) . ',' . $db->quote('*') . ') '
-                        . ' OR contact.language IS NULL)');
+                        . 'OR contact.language IS NULL) ' 
+                        . 'ORDER BY contact.language REGEXP \'^[a-z]\' DESC, contact.language');
                 }
 
                 $db->setQuery($query);

--- a/authorlinks.php
+++ b/authorlinks.php
@@ -116,9 +116,17 @@ class plgContentAuthorlinks extends JPlugin
                 $query = $db->getQuery(true);
 
                 $query->select($db->quoteName('id'));
-                $query->from($db->quoteName('#__contact_details'));
-                $query->where('published = 1');
-                $query->where($db->quoteName('user_id') . ' = ' . (int) $created_by);
+                $query->from($db->quoteName('#__contact_details', 'contact'));
+                $query->where('contact.published = 1');
+                $query->where('contact.user_id = ' . (int) $created_by);
+
+
+                if (JLanguageMultilang::isEnabled() == 1)
+                {
+                    $query->where('(contact.language in '
+                        . '(' . $db->quote(JFactory::getLanguage()->getTag()) . ',' . $db->quote('*') . ') '
+                        . ' OR contact.language IS NULL)');
+                }
 
                 $db->setQuery($query);
                 $result = $db->loadResult();
@@ -140,9 +148,16 @@ class plgContentAuthorlinks extends JPlugin
                 $query = $db->getQuery(true);
                 
                 $query->select($db->quoteName('webpage'));
-                $query->from($db->quoteName('#__contact_details'));
-                $query->where($db->quoteName('user_id') . ' = ' . (int) $author_id);
-                
+                $query->from($db->quoteName('#__contact_details', 'contact'));
+                $query->where($db->quoteName('contact.user_id') . ' = ' . (int) $author_id);
+
+                if (JLanguageMultilang::isEnabled() == 1)
+                {
+                    $query->where('(contact.language in '
+                        . '(' . $db->quote(JFactory::getLanguage()->getTag()) . ',' . $db->quote('*') . ') '
+                        . ' OR contact.language IS NULL)');
+                }
+
                 $db->setQuery($query);
                 $result = $db->loadResult();
                 
@@ -163,9 +178,16 @@ class plgContentAuthorlinks extends JPlugin
                 $query = $db->getQuery(true);
                 
                 $query->select($db->quoteName('email_to'));
-                $query->from($db->quoteName('#__contact_details'));
-                $query->where($db->quoteName('user_id') . ' = ' . (int) $author_id);
-                
+                $query->from($db->quoteName('#__contact_details', 'contact'));
+                $query->where($db->quoteName('contact.user_id') . ' = ' . (int) $author_id);
+
+                if (JLanguageMultilang::isEnabled() == 1)
+                {
+                    $query->where('(contact.language in '
+                        . '(' . $db->quote(JFactory::getLanguage()->getTag()) . ',' . $db->quote('*') . ') '
+                        . ' OR contact.language IS NULL)');
+                }
+
                 $db->setQuery($query);
                 $result = $db->loadResult();
                 

--- a/authorlinks.xml
+++ b/authorlinks.xml
@@ -2,7 +2,7 @@
 <extension version="3.2" type="plugin" group="content" method="upgrade">
         <name>Content - Author Links</name>
         <author>Mattia Verga</author>
-        <creationDate>June 2016</creationDate>
+        <creationDate>15 October 2016</creationDate>
         <copyright>Copyright (C) 2016 Mattia Verga. All rights reserved.</copyright>
         <license>GNU General Public License version 3 or later.</license>
         <authorEmail>mattia.verga@tiscali.it</authorEmail>

--- a/authorlinks.xml
+++ b/authorlinks.xml
@@ -6,7 +6,7 @@
         <copyright>Copyright (C) 2016 Mattia Verga. All rights reserved.</copyright>
         <license>GNU General Public License version 3 or later.</license>
         <authorEmail>mattia.verga@tiscali.it</authorEmail>
-        <version>1.0</version>
+        <version>1.1</version>
         <description>PLG_CONTENT_AUTHORLINKS_XML_DESCRIPTION</description>
         <files>
                 <filename plugin="authorlinks">authorlinks.php</filename>


### PR DESCRIPTION
If multilang is enabled, Authorlinks will use data from a contact assigned to the same language code used in frontend.
If no contact of the same language is present, data from associated contact assigned to "All" language is used.
